### PR TITLE
CWndTListBox

### DIFF
--- a/Documentation/NewFeatures.md
+++ b/Documentation/NewFeatures.md
@@ -25,3 +25,9 @@ Possible bug: it may be applied to everybody even without a parskill (TODO: chec
 - Exp reward is computed over the total hp of a monster, not a mix of the total hp
 and the damage dealt by all the connected players
 
+
+## Guild war
+
+Guild Combats / Eve school / Guild Sieges do not require the guild to have
+the guildmaster or a kingpin. The defender can also be the current guildmaster.
+

--- a/Resource/neuz.ini
+++ b/Resource/neuz.ini
@@ -11,7 +11,7 @@ shadow 2
 bloom 0
 WindowAlpha 255
 SlangWord 0
-ChatCommand 0
+ChatCommand 2
 InstantHelp 1
 Interface 1
 RollEffect 0

--- a/Resource/neuz.ini
+++ b/Resource/neuz.ini
@@ -11,7 +11,7 @@ shadow 2
 bloom 0
 WindowAlpha 255
 SlangWord 0
-ChatCommand 2
+ChatCommand 0
 InstantHelp 1
 Interface 1
 RollEffect 0

--- a/Source/Neuz/DPClient.cpp
+++ b/Source/Neuz/DPClient.cpp
@@ -6287,15 +6287,11 @@ void CDPClient::OnGCSelectPlayer( CAr& ar )
 			{
 				ar >> uidPlayer;
 				vecSelectPlayer.push_back( uidPlayer );
-				if( g_WndMng.m_pWndGuildCombatSelection )
-				{
-					g_WndMng.m_pWndGuildCombatSelection->AddCombatPlayer( uidPlayer );
-				}	
 			}
 			
 			if( g_WndMng.m_pWndGuildCombatSelection )
 			{
-				g_WndMng.m_pWndGuildCombatSelection->SetDefender( uidDefender );
+				g_WndMng.m_pWndGuildCombatSelection->ReceiveLineup(vecSelectPlayer, uidDefender);
 			}	
 		}
 		else

--- a/Source/Neuz/DPClient.cpp
+++ b/Source/Neuz/DPClient.cpp
@@ -13012,23 +13012,16 @@ void CDPClient::OnRunScriptFunc( OBJID objid, CAr & ar )
 				break;
 			}
 		case FUNCTYPE_NEWQUEST:
-			{
-				ar.ReadString( rsf.lpszVal1, 1024 );
-				ar.ReadString( rsf.lpszVal2, 1024 );
-				ar >> rsf.dwVal1;
-				ar >> rsf.dwVal2;
-				if( pWndDialog )
-					pWndDialog->AddNewQuestList( rsf.lpszVal1, rsf.lpszVal2, rsf.dwVal1, rsf.dwVal2 );
-				break;
-			}
 		case FUNCTYPE_CURRQUEST:
 			{
 				ar.ReadString( rsf.lpszVal1, 1024 );
 				ar.ReadString( rsf.lpszVal2, 1024 );
-				ar >> rsf.dwVal1;
+				ar >> rsf.dwVal1; /* always = 0 */
 				ar >> rsf.dwVal2;
-				if( pWndDialog )
-					pWndDialog->AddCurrentQuestList( rsf.lpszVal1, rsf.lpszVal2, rsf.dwVal1, rsf.dwVal2 );
+				if (pWndDialog) {
+					const bool isNewQuest = wFuncType == FUNCTYPE_NEWQUEST;
+					pWndDialog->AddQuestInList(rsf.lpszVal1, rsf.lpszVal2, QuestId(rsf.dwVal2), isNewQuest);
+				}
 				break;
 			}
 		case FUNCTYPE_SETMARK:

--- a/Source/Neuz/Neuz.vcxproj
+++ b/Source/Neuz/Neuz.vcxproj
@@ -688,6 +688,7 @@
     <ClInclude Include="..\_Interface\UserTaskBar.h" />
     <ClInclude Include="..\_Interface\WndComponentSlots.h" />
     <ClInclude Include="..\_Interface\WndSqKComponents.h" />
+    <ClInclude Include="..\_Interface\WndTListBox.hpp" />
     <ClInclude Include="..\_Network\ListedServer.h" />
     <ClInclude Include="CNTREVNT.h" />
     <ClInclude Include="couplehelper.h" />

--- a/Source/Neuz/Neuz.vcxproj.filters
+++ b/Source/Neuz/Neuz.vcxproj.filters
@@ -1892,6 +1892,9 @@
     <ClInclude Include="..\_Network\ListedServer.h">
       <Filter>Source Files\_Network</Filter>
     </ClInclude>
+    <ClInclude Include="..\_Interface\WndTListBox.hpp">
+      <Filter>Source Files\_Interface\WndBase</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Library Include="..\_Common\mss32.lib">

--- a/Source/WORLDSERVER/WorldServer.vcxproj
+++ b/Source/WORLDSERVER/WorldServer.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="DPDatabaseClient.cpp">
     </ClCompile>
     <ClCompile Include="DPSrvr.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Disabled</Optimization>
     </ClCompile>
     <ClCompile Include="DPSrvrLux.cpp">
     </ClCompile>

--- a/Source/_Common/EditString.cpp
+++ b/Source/_Common/EditString.cpp
@@ -36,6 +36,7 @@ CEditString::CEditString( const CEditString& stringSrc ) : CString( stringSrc )
 	Init( stringSrc.m_nWidth, stringSrc.m_sizeFont );
 	m_adwColor.Append( stringSrc.m_adwColor );
 	m_abyStyle.Append( stringSrc.m_abyStyle );
+	m_adwLineOffset.Append(stringSrc.m_adwLineOffset);
 	m_awCodePage.Append( stringSrc.m_awCodePage );
 	InitWordAlignment();
 }
@@ -503,6 +504,8 @@ void CEditString::SetEditString( const CEditString& string )
 	m_abyStyle.Append( string.m_abyStyle );
 	m_awCodePage.RemoveAll();
 	m_awCodePage.Append( string.m_awCodePage );
+	m_adwLineOffset.RemoveAll();
+	m_adwLineOffset.Append( string.m_adwLineOffset );
 	Align( m_pFont, 0 );
 }
 int CEditString::Insert( int nIndex, TCHAR ch, DWORD dwColor, DWORD dwStyle, WORD wCodePage )

--- a/Source/_Common/EditString.h
+++ b/Source/_Common/EditString.h
@@ -111,7 +111,7 @@ public:
 	void AddEditString( const CEditString& string );
 	void SetEditString( const CEditString& string );
 	void Empty( );
-	//void Reset( CD3DFont* pFont, CRect* rect, BOOL bHScroll = FALSE, BOOL bVScroll = TRUE);
+
 	void Align( CD3DFont* pFont, int nBeginLine = 0 );
 	DWORD GetLineCount();
 	DWORD GetLineOffset( DWORD dwLine ) ;

--- a/Source/_Common/ScriptHelper.cpp
+++ b/Source/_Common/ScriptHelper.cpp
@@ -414,11 +414,39 @@ int __EndQuest( int nPcId, int nQuestId, BOOL IsEndQuestCondition )
 	}
 	return 1;
 }
+
+static void AddQuestKeys(
+	int nPcId,
+	std::vector<QuestId> & vecNewQuest,
+	std::vector<QuestId> & vecNextQuest,
+	std::vector<QuestId> & vecEndQuest,
+	std::vector<QuestId> & vecCurrQuest
+) {
+	// sort
+	__QuestSort(vecNewQuest);
+	__QuestSort(vecNextQuest);
+	__QuestSort(vecEndQuest);
+	__QuestSort(vecCurrQuest);
+
+	// send
+	for (const QuestId questId : vecNewQuest)
+		__AddQuestKey(nPcId, questId, "QUEST_BEGIN", true);
+		
+	for (const QuestId questId : vecNextQuest)
+		__AddQuestKey(nPcId, questId, "QUEST_NEXT_LEVEL", true);
+
+	for (const QuestId questId : vecEndQuest)
+		__AddQuestKey(nPcId, questId, "QUEST_END", false);
+
+	for (const QuestId questId : vecCurrQuest)
+		__AddQuestKey(nPcId, questId, "QUEST_END", false);
+}
+
 //int __AddQuestKey( int nPcId, int nQuestId, LPCTSTR lpKey, int nParam = 0 )
-int __AddQuestKey( int nPcId, int nQuestId, LPCTSTR lpKey, int nParam, BOOL bNew )
+int __AddQuestKey( int nPcId, QuestId nQuestId, LPCTSTR lpKey, bool bNew )
 {
 	CHAR szWord[ 128 ], szKey[ 128 ];
-	QuestProp* pQuestProp = prj.m_aPropQuest.GetAt( nQuestId );
+	const QuestProp * pQuestProp = nQuestId.GetProp();
 	if( pQuestProp )
 		strcpy( szWord, pQuestProp->m_szTitle );
 	if( lpKey[0] == '\0' ) 
@@ -434,8 +462,8 @@ int __AddQuestKey( int nPcId, int nQuestId, LPCTSTR lpKey, int nParam, BOOL bNew
 		rsf.wFuncType		= FUNCTYPE_CURRQUEST;
 	lstrcpy( rsf.lpszVal1, szWord );
 	lstrcpy( rsf.lpszVal2, szKey );
-	rsf.dwVal1	= nParam;
-	rsf.dwVal2 = nQuestId;
+	rsf.dwVal1	= 0;
+	rsf.dwVal2 = nQuestId.get();
 	pUser->AddRunScriptFunc( rsf );
 	return 1;
 }
@@ -499,21 +527,7 @@ void __QuestEnd( int nPcId, int nNpcId, int& nGlobal, int nQuestId, BOOL bButtOK
 			}
 		}
 
-		// sort
-		__QuestSort( vecNewQuest );
-		__QuestSort( vecNextQuest );
-		__QuestSort( vecEndQuest );
-		__QuestSort( vecCurrQuest );
-
-		// send
-		for( DWORD i = 0; i < vecNewQuest.size(); ++i )
-			__AddQuestKey( nPcId, vecNewQuest[ i ].get(), "QUEST_BEGIN", 0, TRUE);
-		for( DWORD i = 0; i < vecNextQuest.size(); ++i )
-			__AddQuestKey( nPcId, vecNextQuest[ i ].get(), "QUEST_NEXT_LEVEL", 0, TRUE );
-		for( DWORD i = 0; i < vecEndQuest.size(); ++i )
-			__AddQuestKey( nPcId, vecEndQuest[ i ].get(), "QUEST_END", 0, FALSE );
-		for( DWORD i = 0; i < vecCurrQuest.size(); ++i )
-			__AddQuestKey( nPcId, vecCurrQuest[ i ].get(), "QUEST_END", 0, FALSE );
+		AddQuestKeys(nPcId, vecNewQuest, vecNextQuest, vecEndQuest, vecCurrQuest);
 	}
 	
 	BOOL bDialogText = TRUE;
@@ -650,21 +664,9 @@ void __QuestBeginYes( int nPcId, int nNpcId, int nQuestId )
 				}
 			}
 			
-			// sort
-			__QuestSort( vecNewQuest );
-			__QuestSort( vecNextQuest );
-			__QuestSort( vecEndQuest );
-			__QuestSort( vecCurrQuest );
 			
-			// send
-			for( DWORD i = 0; i < vecNewQuest.size(); ++i )
-				__AddQuestKey( nPcId, vecNewQuest[ i ].get(), "QUEST_BEGIN", 0, TRUE);
-			for( DWORD i = 0; i < vecNextQuest.size(); ++i )
-				__AddQuestKey( nPcId, vecNextQuest[ i ].get(), "QUEST_NEXT_LEVEL", 0, TRUE);
-			for( DWORD i = 0; i < vecEndQuest.size(); ++i )
-				__AddQuestKey( nPcId, vecEndQuest[ i ].get(), "QUEST_END", 0, FALSE);
-			for( DWORD i = 0; i < vecCurrQuest.size(); ++i )
-				__AddQuestKey( nPcId, vecCurrQuest[ i ].get(), "QUEST_END", 0, FALSE);
+
+			AddQuestKeys(nPcId, vecNewQuest, vecNextQuest, vecEndQuest, vecCurrQuest);
 		}
 		pMover->m_pNpcProperty->RunDialog( "#questBeginYes", NULL, 0, nNpcId, nPcId, nQuestId );
 	}

--- a/Source/_Common/ScriptHelper.h
+++ b/Source/_Common/ScriptHelper.h
@@ -13,7 +13,7 @@ int __RemoveAllKey( int nPcId );
 int __SayQuest( int nPcId,int nQuestId, int nIdx );
 int __RunQuest( int nPcId, int nNpcId, int nQuestId );
 int __EndQuest( int nPcId, int nQuestId, BOOL IsEndQuestCondition = TRUE );
-int __AddQuestKey( int nPcId, int nQuestId, LPCTSTR lpKey, int nParam = 0, BOOL bNew = FALSE );
+int __AddQuestKey( int nPcId, QuestId nQuestId, LPCTSTR lpKey, bool bNew);
 void __QuestBegin( int nPcId, int nNpcId, int nQuestId );
 void __QuestEnd( int nPcId, int nNpcId, int& nGlobal, int nQuestId = 0, BOOL bButtOK = FALSE );
 void __QuestBeginYes( int nPcId, int nNpcId, int nQuestId );

--- a/Source/_Common/ScriptLib.cpp
+++ b/Source/_Common/ScriptLib.cpp
@@ -188,7 +188,6 @@ int APIENTRY EndQuest( NPCDIALOG_INFO* pInfo, int nQuest )
 
 int APIENTRY AddQuestKey( NPCDIALOG_INFO* pInfo, int nQuest, LPCTSTR szKey )
 {
-	int nParam = 0;
 	CString strKey = szKey;
 
 	if( strKey.IsEmpty() )
@@ -204,7 +203,7 @@ int APIENTRY AddQuestKey( NPCDIALOG_INFO* pInfo, int nQuest, LPCTSTR szKey )
 		return 1;
 	}
 
-	return __AddQuestKey( pInfo->GetPcId(), nQuest, strKey, nParam );
+	return __AddQuestKey( pInfo->GetPcId(), QuestId(nQuest), strKey, false);
 }
 
 

--- a/Source/_Interface/WndAdminCreateItem.h
+++ b/Source/_Interface/WndAdminCreateItem.h
@@ -1,21 +1,29 @@
-#ifndef __WNDADMINCREATEITEM__H
-#define __WNDADMINCREATEITEM__H
+#pragma once
 
-class CWndAdminCreateItem : public CWndNeuz 
-{ 
-public: 
-	CWndAdminCreateItem(); 
-	~CWndAdminCreateItem(); 
+#include "WndTListBox.hpp"
 
-	CString MakeName( ItemProp *pProp );
+class CWndAdminCreateItem : public CWndNeuz { 
+public:
+	struct Item {
+		CString name;
+		const ItemProp * itemProp;
+
+		explicit Item(const ItemProp * itemProp);
+	};
+
+	struct Displayer {
+		void Render(
+			C2DRender * const p2DRender, const CRect rect,
+			const Item & item, const DWORD color, const WndTListBox::DisplayArgs & misc
+		) const;
+	};
+
+	using ItemPropListBox = CWndTListBox<Item, Displayer>;
 		
 	virtual BOOL Initialize( CWndBase* pWndParent = NULL, DWORD nType = MB_OK ); 
 	virtual BOOL OnChildNotify( UINT message, UINT nID, LRESULT* pLResult ); 
-	virtual void OnDraw( C2DRender* p2DRender ); 
-	virtual	void OnInitialUpdate(); 
-	virtual BOOL OnCommand( UINT nID, DWORD dwMessage, CWndBase* pWndBase ); 
-	virtual void OnSize( UINT nType, int cx, int cy ); 
-	virtual void OnLButtonUp( UINT nFlags, CPoint point ); 
-	virtual void OnLButtonDown( UINT nFlags, CPoint point ); 
+	virtual	void OnInitialUpdate();
+
+private:
+	void UpdateItems(DWORD kind, DWORD sex, DWORD job, DWORD level);
 }; 
-#endif

--- a/Source/_Interface/WndControl.cpp
+++ b/Source/_Interface/WndControl.cpp
@@ -1677,7 +1677,6 @@ void CWndListBox::PaintListBox(C2DRender* p2DRender,CPoint& pt)
 	for (auto [i, pListItem] : m_listItemArray | boost::adaptors::indexed(0)) {
 		int nScrollBarWidth = IsWndStyle( WBS_VSCROLL ) ? m_wndScrollBar.GetClientRect().Width() : 0;
 		
-		p2DRender->m_pFont->GetTextExtent_EditString(pListItem.m_strWord);
 		pListItem.m_rect.left = pt.x;
 		pListItem.m_rect.top = pt.y;
 		pListItem.m_rect.right = pt.x + m_rectWindow.Width() - nScrollBarWidth;
@@ -1809,29 +1808,27 @@ void CWndListBox::OnLButtonDblClk( UINT nFlags, CPoint point)
 		pt.y += m_nFontHeight;
 	}
 }
-void CWndListBox::OnRButtonDblClk( UINT nFlags, CPoint point)
-{
-}
-BOOL CWndListBox::OnMouseWheel( UINT nFlags, short zDelta, CPoint pt )
-{
-	if( m_wndScrollBar.GetScrollPage() >= m_wndScrollBar.GetMaxScrollPos() )
-		return TRUE;
-	if( zDelta < 0 )
-	{
-		if( m_wndScrollBar.GetMaxScrollPos() - m_wndScrollBar.GetScrollPage() > m_wndScrollBar.GetScrollPos() )
-			m_wndScrollBar.SetScrollPos( m_wndScrollBar.GetScrollPos()+1 );
-		else
-			m_wndScrollBar.SetScrollPos( m_wndScrollBar.GetMaxScrollPos() - m_wndScrollBar.GetScrollPage() );
-	}
-	else
-	{
-		if( m_wndScrollBar.GetMinScrollPos() < m_wndScrollBar.GetScrollPos() )
-			m_wndScrollBar.SetScrollPos( m_wndScrollBar.GetScrollPos()-1 );
-		else
-			m_wndScrollBar.SetScrollPos( m_wndScrollBar.GetMinScrollPos() );
-	}
-	
+
+BOOL CWndListBox::OnMouseWheel(UINT, const short zDelta, CPoint) {
+	m_wndScrollBar.MouseWheel(zDelta);
 	return TRUE;
+}
+
+void CWndScrollBar::MouseWheel(const short zDelta) {
+	if (GetScrollPage() >= GetMaxScrollPos())
+		return;
+
+	if (zDelta < 0) {
+		if (GetMaxScrollPos() - GetScrollPage() > GetScrollPos())
+			SetScrollPos(GetScrollPos() + 1);
+		else
+			SetScrollPos(GetMaxScrollPos() - GetScrollPage());
+	} else {
+		if (GetMinScrollPos() < GetScrollPos())
+			SetScrollPos(GetScrollPos() - 1);
+		else
+			SetScrollPos(GetMinScrollPos());
+	}
 }
 
 int CWndListBox::GetCount() const {

--- a/Source/_Interface/WndControl.cpp
+++ b/Source/_Interface/WndControl.cpp
@@ -1863,10 +1863,6 @@ int CWndListBox::SetItemDataPtr(int nIndex, void * pData) {
 	return 0;
 }
 
-DWORD CWndListBox::GetItemData2(int nIndex) const {
-	return m_listItemArray[nIndex].m_dwData2;
-}
-
 BOOL CWndListBox::GetItemValidity(int nIndex) {
 	return m_listItemArray[nIndex].m_bIsValid;
 }

--- a/Source/_Interface/WndControl.h
+++ b/Source/_Interface/WndControl.h
@@ -248,6 +248,8 @@ public:
 	virtual void OnMouseMove(UINT nFlags, CPoint point);
 	virtual BOOL OnCommand( UINT nID, DWORD dwMessage, CWndBase* pWndBase = NULL );
 	virtual void OnSize(UINT nType, int cx, int cy);
+
+	void MouseWheel(short zDelta);
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -768,7 +770,6 @@ public:
 	virtual void OnRButtonUp(UINT nFlags, CPoint point);
 	virtual void OnRButtonDown(UINT nFlags, CPoint point);
 	virtual void OnLButtonDblClk( UINT nFlags, CPoint point);
-	virtual void OnRButtonDblClk( UINT nFlags, CPoint point);
 	virtual void OnSize(UINT nType, int cx, int cy);
 	virtual BOOL OnEraseBkgnd( C2DRender* p2DRender );
 	virtual	void PaintFrame( C2DRender* p2DRender );
@@ -776,6 +777,9 @@ public:
 	virtual BOOL OnMouseWheel( UINT nFlags, short zDelta, CPoint pt );
 };
 // class CListCtrl  CButton
+
+
+#include "WndTListBox.hpp"
 
 /////////////////////////////////////////////////////////////////////////////
 // CListCtrl

--- a/Source/_Interface/WndControl.h
+++ b/Source/_Interface/WndControl.h
@@ -704,7 +704,6 @@ public:
 		BOOL        m_bIsValid   = TRUE;
 		DWORD       m_dwData     = 0;
 		CString     m_strKey     = _T("");
-		DWORD       m_dwData2    = 0;
 	};
 
 protected:
@@ -734,7 +733,6 @@ public:
 	void* GetItemDataPtr(int nIndex) const;
 	int   SetItemData(int nIndex,DWORD dwItemData);
 	int   SetItemDataPtr(int nIndex,void* pData);
-	DWORD GetItemData2( int nIndex ) const;
 	BOOL GetItemValidity( int nIndex );
 	const CRect& GetItemRect( int nIndex ) const;
 	void  GetText(int nIndex,CString& rString) const;

--- a/Source/_Interface/WndDialog.cpp
+++ b/Source/_Interface/WndDialog.cpp
@@ -48,9 +48,9 @@ void CWndDialog::OnDraw( C2DRender* p2DRender )
 	int i;
 	if( m_bSay == TRUE )
 		p2DRender->TextOut_EditString( pt.x, pt.y, m_string, 0, 0, 6 );
-	else if( strcmp( m_aKeyButton[ m_nSelectKeyButton ].szWord, prj.GetText( TID_GAME_NEW_QUEST ) ) == 0 && m_nNewQuestListNumber == 0 )
+	else if( strcmp( m_aKeyButton[ m_nSelectKeyButton ].szWord, prj.GetText( TID_GAME_NEW_QUEST ) ) == 0 && m_newQuestListBox.IsEmpty())
 		p2DRender->TextOut( pt.x + 10, pt.y + 10, prj.GetText( TID_GAME_EMPTY_NEW_QUEST ), D3DCOLOR_ARGB( 255, 0, 0, 0 ) );
-	else if( strcmp( m_aKeyButton[ m_nSelectKeyButton ].szWord, prj.GetText( TID_GAME_CURRENT_QUEST ) ) == 0 && m_nCurrentQuestListNumber == 0 )
+	else if( strcmp( m_aKeyButton[ m_nSelectKeyButton ].szWord, prj.GetText( TID_GAME_CURRENT_QUEST ) ) == 0 && m_currentQuestListBox.IsEmpty())
 		p2DRender->TextOut( pt.x + 10, pt.y + 10, prj.GetText( TID_GAME_EMPTY_CURRENT_QUEST ), D3DCOLOR_ARGB( 255, 0, 0, 0 ) );
 	if( m_bWordButtonEnable )
 	{
@@ -93,10 +93,7 @@ void CWndDialog::OnDraw( C2DRender* p2DRender )
 		p2DRender->TextOut( pKeyButton->rect.left, pKeyButton->rect.top,  pKeyButton->szWord, dwColor );
 		p2DRender->TextOut( pKeyButton->rect.left + 1, pKeyButton->rect.top,  pKeyButton->szWord, dwColor );
 	}
-	if( m_WndNewQuestListBox.IsVisible() == TRUE )
-		RenderNewQuestListIcon( p2DRender );
-	else if( m_WndCurrentQuestListBox.IsVisible() == TRUE )
-		RenderCurrentQuestListIcon( p2DRender );
+
 	for( i = 0; i < m_nContextButtonNum; i++ )
 	{
 		DWORD dwColor = 0xff101010;
@@ -216,10 +213,6 @@ void CWndDialog::OnInitialUpdate()
 		pWndGroupBox->SetTitle( prj.GetText( TID_GAME_DIALOG ) );
 	}
 
-	m_pNewQuestListIconTexture = CWndBase::m_textureMng.AddTexture( g_Neuz.m_pd3dDevice, MakePath( DIR_THEME, _T( "QuestUiPaperGreen.tga" )), 0xffffffff );
-	m_pExpectedQuestListIconTexture = CWndBase::m_textureMng.AddTexture( g_Neuz.m_pd3dDevice, MakePath( DIR_THEME, _T( "QuestUiPaperRed.tga" )), 0xffffffff );
-	m_pCurrentQuestListIconTexture = CWndBase::m_textureMng.AddTexture( g_Neuz.m_pd3dDevice, MakePath( DIR_THEME, _T( "QuestUiPaperGray.tga" )), 0xffffffff );
-	m_pCompleteQuestListIconTexture = CWndBase::m_textureMng.AddTexture( g_Neuz.m_pd3dDevice, MakePath( DIR_THEME, _T( "QuestUiPaperYellow.tga" )), 0xffffffff );
 
 	LPWNDCTRL lpWndCtrl = GetWndCtrl( WIDC_CUSTOM1 );
 	lpWndCtrl->dwWndStyle |= WBS_VSCROLL;
@@ -227,24 +220,29 @@ void CWndDialog::OnInitialUpdate()
 	static const int QUEST_LIST_SELECT_COLOR = 0xffff0000;
 	static const int QUEST_LIST_LINE_SPACE = 3;
 
-	m_WndNewQuestListBox.Create( lpWndCtrl->dwWndStyle, lpWndCtrl->rect, this, lpWndCtrl->dwWndId );
-	m_WndNewQuestListBox.m_nSelectColor = QUEST_LIST_SELECT_COLOR;
-	m_WndNewQuestListBox.m_nLineSpace = QUEST_LIST_LINE_SPACE;
-	if( m_pNewQuestListIconTexture )
-		m_WndNewQuestListBox.SetLeftMargin( m_pNewQuestListIconTexture->m_size.cx );
-	m_WndNewQuestListBox.SetVisible( FALSE );
+	m_newQuestListBox.Create( lpWndCtrl->dwWndStyle, lpWndCtrl->rect, this, WIDC_NewQuests);
+	m_newQuestListBox.selectColor = QUEST_LIST_SELECT_COLOR;
+	m_newQuestListBox.lineHeight = m_pFont->GetMaxHeight() + QUEST_LIST_LINE_SPACE * 2;
+	m_newQuestListBox.SetVisible( FALSE );
 
-	m_WndCurrentQuestListBox.Create( lpWndCtrl->dwWndStyle, lpWndCtrl->rect, this, lpWndCtrl->dwWndId );
-	m_WndCurrentQuestListBox.m_nSelectColor = QUEST_LIST_SELECT_COLOR;
-	m_WndCurrentQuestListBox.m_nLineSpace = QUEST_LIST_LINE_SPACE;
-	if( m_pCurrentQuestListIconTexture )
-		m_WndCurrentQuestListBox.SetLeftMargin( m_pCurrentQuestListIconTexture->m_size.cx );
-	m_WndCurrentQuestListBox.SetVisible( FALSE );
+	m_newQuestListBox.displayer.m_pNewQuestListIconTexture = CWndBase::m_textureMng.AddTexture(g_Neuz.m_pd3dDevice, MakePath(DIR_THEME, _T("QuestUiPaperGreen.tga")), 0xffffffff);
+	m_newQuestListBox.displayer.m_pExpectedQuestListIconTexture = CWndBase::m_textureMng.AddTexture(g_Neuz.m_pd3dDevice, MakePath(DIR_THEME, _T("QuestUiPaperRed.tga")), 0xffffffff);
+	m_newQuestListBox.displayer.xOffset = m_newQuestListBox.displayer.m_pNewQuestListIconTexture->m_size.cx;
+
+
+	m_currentQuestListBox.Create( lpWndCtrl->dwWndStyle, lpWndCtrl->rect, this, WIDC_CurrentQuests);
+	m_currentQuestListBox.selectColor = QUEST_LIST_SELECT_COLOR;
+	m_currentQuestListBox.lineHeight = m_pFont->GetMaxHeight() + QUEST_LIST_LINE_SPACE * 2;
+	m_currentQuestListBox.SetVisible( FALSE );
+
+	m_currentQuestListBox.displayer.m_pCurrentQuestListIconTexture = CWndBase::m_textureMng.AddTexture(g_Neuz.m_pd3dDevice, MakePath(DIR_THEME, _T("QuestUiPaperGray.tga")), 0xffffffff);
+	m_currentQuestListBox.displayer.m_pCompleteQuestListIconTexture = CWndBase::m_textureMng.AddTexture(g_Neuz.m_pd3dDevice, MakePath(DIR_THEME, _T("QuestUiPaperYellow.tga")), 0xffffffff);
+	m_currentQuestListBox.displayer.xOffset = m_currentQuestListBox.displayer.m_pCurrentQuestListIconTexture->m_size.cx;
+
+
 	
-	CWndBase* pWndBase = (CWndBase*)g_WndMng.GetApplet( APP_INVENTORY );
 
-	if( pWndBase )
-	{
+	if (CWndBase * pWndBase = g_WndMng.GetApplet(APP_INVENTORY)) {
 		pWndBase->Destroy();
 	}
 	
@@ -333,22 +331,22 @@ void CWndDialog::OnLButtonUp( UINT nFlags, CPoint point )
 			m_bSay = FALSE;
 			BeginText();
  			LPWNDCTRL lpWndCustom1 = GetWndCtrl( WIDC_CUSTOM1 );
-			if( strcmp( m_aKeyButton[ i ].szWord, prj.GetText( TID_GAME_NEW_QUEST ) ) == 0 && m_nNewQuestListNumber > 0 )
+			if( strcmp( m_aKeyButton[ i ].szWord, prj.GetText( TID_GAME_NEW_QUEST ) ) == 0 && !m_newQuestListBox.IsEmpty())
 			{
-				m_WndNewQuestListBox.SetVisible( TRUE );
-				m_WndNewQuestListBox.SetFocus();
-				m_WndCurrentQuestListBox.SetVisible( FALSE );
+				m_newQuestListBox.SetVisible( TRUE );
+				m_newQuestListBox.SetFocus();
+				m_currentQuestListBox.SetVisible( FALSE );
 			}
-			else if( strcmp( m_aKeyButton[ i ].szWord, prj.GetText( TID_GAME_CURRENT_QUEST ) ) == 0 && m_nCurrentQuestListNumber > 0 )
+			else if( strcmp( m_aKeyButton[ i ].szWord, prj.GetText( TID_GAME_CURRENT_QUEST ) ) == 0 && !m_currentQuestListBox.IsEmpty())
 			{
-				m_WndCurrentQuestListBox.SetVisible( TRUE );
-				m_WndCurrentQuestListBox.SetFocus();
-				m_WndNewQuestListBox.SetVisible( FALSE );
+				m_currentQuestListBox.SetVisible( TRUE );
+				m_currentQuestListBox.SetFocus();
+				m_newQuestListBox.SetVisible( FALSE );
 			}
 			else
 			{
-				m_WndNewQuestListBox.SetVisible( FALSE );
-				m_WndCurrentQuestListBox.SetVisible( FALSE );
+				m_newQuestListBox.SetVisible( FALSE );
+				m_currentQuestListBox.SetVisible( FALSE );
 				RunScript( m_aKeyButton[i].szKey, m_aKeyButton[i].dwParam, m_aKeyButton[i].dwParam2 );
 			}
 			MakeKeyButton();
@@ -658,10 +656,8 @@ void CWndDialog::AddKeyButton( LPCTSTR lpszWord, LPCTSTR lpszKey, DWORD dwParam,
 }
 void CWndDialog::RemoveAllKeyButton()
 {
-	m_WndNewQuestListBox.ResetContent();
-	m_nNewQuestListNumber = 0;
-	m_WndCurrentQuestListBox.ResetContent();
-	m_nCurrentQuestListNumber = 0;
+	m_newQuestListBox.ResetContent();
+	m_currentQuestListBox.ResetContent();
 	m_nKeyButtonNum = 0;
 	EndSay();
 }
@@ -870,61 +866,48 @@ BOOL CWndDialog::OnChildNotify( UINT message, UINT nID, LRESULT* pLResult )
 			UpdateButtonEnable();
 		}
 		break;
-	case WIDC_CUSTOM1:
-		{
-			if( m_WndNewQuestListBox.IsVisible() == TRUE && m_WndCurrentQuestListBox.IsVisible() == FALSE )
-			{
-				for( int i = 0; i < m_nNewQuestListNumber; ++i )
-				{
-					CRect rect = m_WndNewQuestListBox.GetItemRect( i );
-					CPoint point = m_WndNewQuestListBox.GetMousePoint();
-					if( rect.PtInRect( point ) )
-					{
-						if( strcmp( m_WndNewQuestListBox.GetKeyString( i ), "QUEST_NEXT_LEVEL" ) != 0 )
-						{
-							m_bSay = FALSE;
-							m_WndNewQuestListBox.SetVisible( FALSE );
-							BeginText();
-							RunScript( m_WndNewQuestListBox.GetKeyString( i ), m_WndNewQuestListBox.GetItemData( i ), m_WndNewQuestListBox.GetItemData2( i ) );
-							MakeKeyButton();
-							UpdateButtonEnable();
-						}
-					}
-				}
+	case WIDC_NewQuests: {
+		ListedQuest * quest = m_newQuestListBox.GetCurSelItem();
+		if (quest) {
+			if (quest->strKey != "QUEST_NEXT_LEVEL") {
+				m_bSay = FALSE;
+				m_newQuestListBox.SetVisible(FALSE);
+				BeginText();
+				RunScript(quest->strKey, quest->dwParam, quest->questId.get());
+				MakeKeyButton();
+				UpdateButtonEnable();
 			}
-			else if( m_WndNewQuestListBox.IsVisible() == FALSE && m_WndCurrentQuestListBox.IsVisible() == TRUE )
-			{
-				for( int i = 0; i < m_nCurrentQuestListNumber; ++i )
-				{
-					CRect rect = m_WndCurrentQuestListBox.GetItemRect( i );
-					CPoint point = m_WndCurrentQuestListBox.GetMousePoint();
-					if( rect.PtInRect( point ) )
-					{
-						m_bSay = FALSE;
-						m_WndCurrentQuestListBox.SetVisible( FALSE );
-						BeginText();
-						RunScript( m_WndCurrentQuestListBox.GetKeyString( i ), m_WndCurrentQuestListBox.GetItemData( i ), m_WndCurrentQuestListBox.GetItemData2( i ) );
-						MakeKeyButton();
-						UpdateButtonEnable();
-					}
-				}
-			}
-			break;
 		}
+		break;
+	}
+	case WIDC_CurrentQuests: {
+		ListedQuest * quest = m_currentQuestListBox.GetCurSelItem();
+		if (quest) {
+			m_bSay = FALSE;
+			m_currentQuestListBox.SetVisible(FALSE);
+			BeginText();
+			RunScript(quest->strKey, quest->dwParam, quest->questId.get());
+			MakeKeyButton();
+			UpdateButtonEnable();
+		}
+		break;
+	}
 	}
 	return CWndNeuz::OnChildNotify( message, nID, pLResult );
 }
 
-void CWndDialog::AddNewQuestList( const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest )
-{
-	MakeQuestKeyButton( prj.GetText( TID_GAME_NEW_QUEST ) );
-	AddQuestList( m_WndNewQuestListBox, m_nNewQuestListNumber, lpszWord, lpszKey, dwParam, dwQuest );
+void CWndDialog::AddNewQuestList(const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest) {
+	MakeQuestKeyButton(prj.GetText(TID_GAME_NEW_QUEST));
+	const auto [elem, isValid] = MakeListedQuest(lpszWord, lpszKey, dwParam, dwQuest);
+	m_newQuestListBox.Add(elem).isValid = isValid;
 }
-void CWndDialog::AddCurrentQuestList( const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest )
-{
-	MakeQuestKeyButton( prj.GetText( TID_GAME_CURRENT_QUEST ) );
-	AddQuestList( m_WndCurrentQuestListBox, m_nCurrentQuestListNumber, lpszWord, lpszKey, dwParam, dwQuest );
+
+void CWndDialog::AddCurrentQuestList(const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest) {
+	MakeQuestKeyButton(prj.GetText(TID_GAME_CURRENT_QUEST));
+	const auto [elem, isValid] = MakeListedQuest(lpszWord, lpszKey, dwParam, dwQuest);
+	m_currentQuestListBox.Add(elem).isValid = isValid;
 }
+
 void CWndDialog::MakeQuestKeyButton( const CString& rstrKeyButton )
 {
 	WORDBUTTON* lpKeyButton = NULL;
@@ -943,64 +926,87 @@ void CWndDialog::MakeQuestKeyButton( const CString& rstrKeyButton )
 	++m_nKeyButtonNum;
 	EndSay();
 }
-void CWndDialog::RenderNewQuestListIcon( C2DRender* p2DRender )
-{
-	LPWNDCTRL lpWndCtrl = GetWndCtrl( WIDC_CUSTOM1 );
-	if( lpWndCtrl == NULL || m_pNewQuestListIconTexture == NULL || m_pExpectedQuestListIconTexture == NULL )
-		return;
-	POINT pt = lpWndCtrl->rect.TopLeft();
-	for( int i = 0; i < m_WndNewQuestListBox.GetCount(); ++i )
-	{
-		CRect rectItem = m_WndNewQuestListBox.GetItemRect( i );
-		int nRenderPositionX = pt.x + rectItem.left;
-		int nRenderPositionY = pt.y + rectItem.top;
-		if( ( nRenderPositionY >= lpWndCtrl->rect.top ) && ( nRenderPositionY + rectItem.Height() <= lpWndCtrl->rect.bottom ) )
-		{
-			if( m_WndNewQuestListBox.GetItemValidity( i ) == FALSE )
-				p2DRender->RenderTexture( CPoint( nRenderPositionX, nRenderPositionY ), m_pExpectedQuestListIconTexture );
-			else
-				p2DRender->RenderTexture( CPoint( nRenderPositionX, nRenderPositionY ), m_pNewQuestListIconTexture );
-		}
-	}
+
+void CWndDialog::NewQuestDisplayer::Render(
+	C2DRender * p2DRender,
+	CWndDialog::ListedQuest & quest,
+	CRect rect,
+	DWORD color,
+	WndTListBox::DisplayArgs misc
+) {
+
+	if (misc.isValid)
+		p2DRender->RenderTexture(rect.TopLeft(), m_pExpectedQuestListIconTexture);
+	else
+		p2DRender->RenderTexture(rect.TopLeft(), m_pNewQuestListIconTexture);
+
+
+	quest.theEditStringClassIsSoBad.Format(
+		_T("[#b%d#nb~#b%d#nb ] #b%s#nb"),
+		quest.questId.GetProp()->m_nBeginCondLevelMin,
+		quest.questId.GetProp()->m_nBeginCondLevelMax,
+		quest.questId.GetProp()->m_szTitle
+	);
+	
+	quest.theEditStringClassIsSoBad.Init(p2DRender->m_pFont, &p2DRender->m_clipRect);
+	quest.theEditStringClassIsSoBad.SetParsingString(quest.questName.GetString(), 0xFF3C3C3C, 0x00000000, 0, 0x00000001, TRUE);
+
+	quest.theEditStringClassIsSoBad.SetColor(color);
+
+	p2DRender->TextOut_EditString(xOffset + rect.left, rect.top, quest.theEditStringClassIsSoBad);
 }
-void CWndDialog::RenderCurrentQuestListIcon( C2DRender* p2DRender )
-{
-	LPWNDCTRL lpWndCtrl = GetWndCtrl( WIDC_CUSTOM1 );
-	if( lpWndCtrl == NULL || m_pCurrentQuestListIconTexture == NULL || m_pCompleteQuestListIconTexture == NULL )
-		return;
-	POINT pt = lpWndCtrl->rect.TopLeft();
-	for( int i = 0; i < m_WndCurrentQuestListBox.GetCount(); ++i )
-	{
-		CRect rectItem = m_WndCurrentQuestListBox.GetItemRect( i );
-		int nRenderPositionX = pt.x + rectItem.left;
-		int nRenderPositionY = pt.y + rectItem.top;
-		if( ( nRenderPositionY >= lpWndCtrl->rect.top ) && ( nRenderPositionY + rectItem.Height() <= lpWndCtrl->rect.bottom ) )
-		{
-			if( __IsEndQuestCondition( g_pPlayer->GetActiveMover(), m_WndCurrentQuestListBox.GetItemData2( i ) ) )
-				p2DRender->RenderTexture( CPoint( nRenderPositionX, nRenderPositionY ), m_pCompleteQuestListIconTexture );
-			else
-				p2DRender->RenderTexture( CPoint( nRenderPositionX, nRenderPositionY ), m_pCurrentQuestListIconTexture );
-		}
-	}
+
+void CWndDialog::CurrentQuestDisplayer::Render(
+	C2DRender * p2DRender,
+	CWndDialog::ListedQuest & quest,
+	CRect rect,
+	DWORD color,
+	WndTListBox::DisplayArgs misc
+) {
+	if (__IsEndQuestCondition(g_pPlayer->GetActiveMover(), quest.questId.get()))
+		p2DRender->RenderTexture(rect.TopLeft(), m_pCompleteQuestListIconTexture);
+	else
+		p2DRender->RenderTexture(rect.TopLeft(), m_pCurrentQuestListIconTexture);
+
+	quest.theEditStringClassIsSoBad.Format(
+		_T("[#b%d#nb~#b%d#nb ] #b%s#nb"),
+		quest.questId.GetProp()->m_nBeginCondLevelMin,
+		quest.questId.GetProp()->m_nBeginCondLevelMax,
+		quest.questId.GetProp()->m_szTitle
+	);
+
+	quest.theEditStringClassIsSoBad.Init(p2DRender->m_pFont, &p2DRender->m_clipRect);
+	quest.theEditStringClassIsSoBad.SetParsingString(quest.questName.GetString(), 0xFF3C3C3C, 0x00000000, 0, 0x00000001, TRUE);
+
+	quest.theEditStringClassIsSoBad.SetColor(color);
+
+	p2DRender->TextOut_EditString(xOffset + rect.left, rect.top, quest.theEditStringClassIsSoBad);
 }
-void CWndDialog::AddQuestList( CWndListBox& pWndListBox, int& nQuestListNumber, const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest )
+
+
+std::pair<CWndDialog::ListedQuest, bool> CWndDialog::MakeListedQuest(const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest )
 {
-	for( int i = 0; i < nQuestListNumber; ++i )
-	{
-		CString strQuestList = pWndListBox.GetString( i );
-		if( strcmp( strQuestList, lpszWord ) == 0 )
-			return;
-	}
+	//for( int i = 0; i < nQuestListNumber; ++i )
+	//{
+	//	CString strQuestList = pWndListBox.GetString( i );
+	//	if( strcmp( strQuestList, lpszWord ) == 0 )
+	//		return;
+	//}
+	CWndDialog::ListedQuest listed;
+
 	CEditString strTitleWord = _T( "" );
 	QuestProp* pQuestProp = prj.m_aPropQuest.GetAt( dwQuest );
 	if( pQuestProp )
 		strTitleWord.Format( _T( "[#b%d#nb~#b%d#nb ] #b%s#nb" ), pQuestProp->m_nBeginCondLevelMin, pQuestProp->m_nBeginCondLevelMax, lpszWord );
-	CWndListBox::LISTITEM & item = pWndListBox.AddString(strTitleWord);
-	if (strcmp(lpszKey, _T("QUEST_NEXT_LEVEL")) == 0)
-		item.m_bIsValid = FALSE;
+	
+	// I love doing complicated things for literally nothing
+	listed.questName = strTitleWord.GetString();
 
-	item.m_strKey = lpszKey;
-	item.m_dwData = dwParam;
-	item.m_dwData2 = dwQuest;
-	++nQuestListNumber;
+	// ok
+	const bool isValid = lpszKey == std::string_view(_T("QUEST_NEXT_LEVEL"));
+	listed.strKey = lpszKey;
+	listed.dwParam = dwParam;
+	listed.questId = QuestId(dwQuest);
+
+	return std::make_pair(listed, isValid);
 }

--- a/Source/_Interface/WndDialog.cpp
+++ b/Source/_Interface/WndDialog.cpp
@@ -206,23 +206,22 @@ void CWndDialog::OnInitialUpdate()
 { 
 	CWndNeuz::OnInitialUpdate(); 
 
-	CWndGroupBox* pWndGroupBox = ( CWndGroupBox* )GetDlgItem( WIDC_GROUP_BOX_TITLE );
-	if( pWndGroupBox )
-	{
-		pWndGroupBox->m_dwColor = D3DCOLOR_ARGB( 255, 128, 0, 64 );
-		pWndGroupBox->SetTitle( prj.GetText( TID_GAME_DIALOG ) );
+	if (CWndGroupBox * pWndGroupBox = dynamic_cast<CWndGroupBox *>(GetDlgItem(WIDC_GROUP_BOX_TITLE))) {
+		// TODO: CWndGroupBox is never instanciated. Is it in v21 source code?
+		pWndGroupBox->m_dwColor = D3DCOLOR_ARGB(255, 128, 0, 64);
+		pWndGroupBox->SetTitle(prj.GetText(TID_GAME_DIALOG));
 	}
 
 
 	LPWNDCTRL lpWndCtrl = GetWndCtrl( WIDC_CUSTOM1 );
 	lpWndCtrl->dwWndStyle |= WBS_VSCROLL;
 
-	static const int QUEST_LIST_SELECT_COLOR = 0xffff0000;
-	static const int QUEST_LIST_LINE_SPACE = 3;
+	static constexpr int QUEST_LIST_SELECT_COLOR = 0xffff0000;
+	static constexpr int QUEST_LIST_LINE_SPACE = 3;
 
 	m_newQuestListBox.Create( lpWndCtrl->dwWndStyle, lpWndCtrl->rect, this, WIDC_NewQuests);
-	m_newQuestListBox.selectColor = QUEST_LIST_SELECT_COLOR;
-	m_newQuestListBox.lineHeight = m_pFont->GetMaxHeight() + QUEST_LIST_LINE_SPACE * 2;
+	m_newQuestListBox.ChangeSelectColor(QUEST_LIST_SELECT_COLOR);
+	m_newQuestListBox.SetLineSpace(QUEST_LIST_LINE_SPACE);
 	m_newQuestListBox.SetVisible( FALSE );
 
 	m_newQuestListBox.displayer.m_pNewQuestListIconTexture = CWndBase::m_textureMng.AddTexture(g_Neuz.m_pd3dDevice, MakePath(DIR_THEME, _T("QuestUiPaperGreen.tga")), 0xffffffff);
@@ -231,8 +230,8 @@ void CWndDialog::OnInitialUpdate()
 
 
 	m_currentQuestListBox.Create( lpWndCtrl->dwWndStyle, lpWndCtrl->rect, this, WIDC_CurrentQuests);
-	m_currentQuestListBox.selectColor = QUEST_LIST_SELECT_COLOR;
-	m_currentQuestListBox.lineHeight = m_pFont->GetMaxHeight() + QUEST_LIST_LINE_SPACE * 2;
+	m_currentQuestListBox.ChangeSelectColor(QUEST_LIST_SELECT_COLOR);
+	m_currentQuestListBox.SetLineSpace(QUEST_LIST_LINE_SPACE);
 	m_currentQuestListBox.SetVisible( FALSE );
 
 	m_currentQuestListBox.displayer.m_pCurrentQuestListIconTexture = CWndBase::m_textureMng.AddTexture(g_Neuz.m_pd3dDevice, MakePath(DIR_THEME, _T("QuestUiPaperGray.tga")), 0xffffffff);
@@ -241,10 +240,7 @@ void CWndDialog::OnInitialUpdate()
 
 
 	
-
-	if (CWndBase * pWndBase = g_WndMng.GetApplet(APP_INVENTORY)) {
-		pWndBase->Destroy();
-	}
+	Windows::DestroyIfOpened(APP_INVENTORY);
 	
 	CMover* pMover = prj.GetMover( m_idMover );
 	if( pMover == NULL ) return;
@@ -903,10 +899,10 @@ void CWndDialog::AddQuestInList(const LPCTSTR lpszWord, const LPCTSTR lpszKey, c
 
 	if (isNewQuest) {
 		MakeQuestKeyButton(prj.GetText(TID_GAME_NEW_QUEST));
-		m_newQuestListBox.Add(elem).isValid = isValid;
+		m_newQuestListBox.Add(elem, isValid);
 	} else {
 		MakeQuestKeyButton(prj.GetText(TID_GAME_CURRENT_QUEST));
-		m_currentQuestListBox.Add(elem).isValid = isValid;
+		m_currentQuestListBox.Add(elem, isValid);
 	}
 }
 
@@ -930,9 +926,10 @@ void CWndDialog::MakeQuestKeyButton( const CString& rstrKeyButton )
 }
 
 void CWndDialog::NewQuestDisplayer::Render(
-	C2DRender * p2DRender, CWndDialog::ListedQuest & quest,
-	CRect rect, DWORD color, WndTListBox::DisplayArgs misc
-) {
+	C2DRender * p2DRender, CRect rect,
+	ListedQuest & quest, DWORD color,
+	const WndTListBox::DisplayArgs & misc
+) const {
 	CTexture * icon = misc.isValid ? m_pNewQuestListIconTexture : m_pExpectedQuestListIconTexture;
 	p2DRender->RenderTexture(rect.TopLeft(), icon);
 
@@ -941,9 +938,10 @@ void CWndDialog::NewQuestDisplayer::Render(
 }
 
 void CWndDialog::CurrentQuestDisplayer::Render(
-	C2DRender * p2DRender, CWndDialog::ListedQuest & quest,
-	CRect rect, DWORD color, WndTListBox::DisplayArgs
-) {
+	C2DRender * p2DRender, CRect rect,
+	ListedQuest & quest, DWORD color,
+	const WndTListBox::DisplayArgs &
+) const {
 	CTexture * icon = __IsEndQuestCondition(g_pPlayer->GetActiveMover(), quest.questId.get())
 		? m_pCompleteQuestListIconTexture
 		: m_pCurrentQuestListIconTexture;

--- a/Source/_Interface/WndDialog.cpp
+++ b/Source/_Interface/WndDialog.cpp
@@ -1003,7 +1003,7 @@ std::pair<CWndDialog::ListedQuest, bool> CWndDialog::MakeListedQuest(const LPCTS
 	listed.questName = strTitleWord.GetString();
 
 	// ok
-	const bool isValid = lpszKey == std::string_view(_T("QUEST_NEXT_LEVEL"));
+	const bool isValid = lpszKey != std::string_view(_T("QUEST_NEXT_LEVEL"));
 	listed.strKey = lpszKey;
 	listed.dwParam = dwParam;
 	listed.questId = QuestId(dwQuest);

--- a/Source/_Interface/WndDialog.h
+++ b/Source/_Interface/WndDialog.h
@@ -63,12 +63,9 @@ private:
 		int xOffset = 0;
 
 		void Render(
-			C2DRender * p2DRender,
-			ListedQuest & questId,
-			CRect rect,
-			DWORD color,
-			WndTListBox::DisplayArgs misc
-		);
+			C2DRender * p2DRender, CRect rect,
+			ListedQuest & quest, DWORD color, const WndTListBox::DisplayArgs & misc
+		) const;
 	};
 
 	struct CurrentQuestDisplayer {
@@ -77,23 +74,14 @@ private:
 		int xOffset = 0;
 
 		void Render(
-			C2DRender * p2DRender,
-			ListedQuest & questId,
-			CRect rect,
-			DWORD color,
-			WndTListBox::DisplayArgs misc
-		);
+			C2DRender * p2DRender, CRect rect,
+			ListedQuest & quest, DWORD color, const WndTListBox::DisplayArgs & misc
+		) const;
 	};
 
 	CWndTListBox<ListedQuest, NewQuestDisplayer> m_newQuestListBox;
 	CWndTListBox<ListedQuest, CurrentQuestDisplayer> m_currentQuestListBox;
 
-//	CWndListBox m_WndNewQuestListBox;
-//	CWndListBox m_WndCurrentQuestListBox;
-//	CTexture* m_pNewQuestListIconTexture = nullptr;
-//	CTexture* m_pExpectedQuestListIconTexture = nullptr;
-//	CTexture* m_pCurrentQuestListIconTexture = nullptr;
-//	CTexture* m_pCompleteQuestListIconTexture = nullptr;
 public:
 	 
 	CWndDialog() = default;

--- a/Source/_Interface/WndDialog.h
+++ b/Source/_Interface/WndDialog.h
@@ -1,10 +1,15 @@
 #pragma once
 
 #include <array>
+#include <memory>
+#include "WndTListBox.hpp"
 
 class CWndDialog : public CWndNeuz 
 { 
 public:
+	static constexpr UINT WIDC_NewQuests = 901;
+	static constexpr UINT WIDC_CurrentQuests = 902;
+
 	struct WORDBUTTON {
 		BOOL bStatus;
 		CRect rect;
@@ -30,8 +35,6 @@ public:
 	int m_nWordButtonNum = 0;
 	int m_nKeyButtonNum  = 0;
 	int m_nContextButtonNum = 0;
-	int m_nNewQuestListNumber = 0;
-	int m_nCurrentQuestListNumber = 0;
 	int m_nSelectKeyButton = - 1;
 	CUIntArray m_aContextMark[ 32 ];
 
@@ -46,13 +49,53 @@ public:
 	CPtrArray m_strArray;
 	OBJID m_idMover;
 	CMapStringToString m_mapWordToOriginal;
+
+	struct ListedQuest {
+		CEditString theEditStringClassIsSoBad;
+		CString questName;
+		CString strKey;
+		DWORD dwParam;
+		QuestId questId;
+	};
+
 private:
-	CWndListBox m_WndNewQuestListBox;
-	CWndListBox m_WndCurrentQuestListBox;
-	CTexture* m_pNewQuestListIconTexture = nullptr;
-	CTexture* m_pExpectedQuestListIconTexture = nullptr;
-	CTexture* m_pCurrentQuestListIconTexture = nullptr;
-	CTexture* m_pCompleteQuestListIconTexture = nullptr;
+	struct NewQuestDisplayer {
+		CTexture * m_pExpectedQuestListIconTexture = nullptr;
+		CTexture * m_pNewQuestListIconTexture = nullptr;
+		int xOffset = 0;
+
+		void Render(
+			C2DRender * p2DRender,
+			ListedQuest & questId,
+			CRect rect,
+			DWORD color,
+			WndTListBox::DisplayArgs misc
+		);
+	};
+
+	struct CurrentQuestDisplayer {
+		CTexture * m_pCompleteQuestListIconTexture = nullptr;
+		CTexture * m_pCurrentQuestListIconTexture = nullptr;
+		int xOffset = 0;
+
+		void Render(
+			C2DRender * p2DRender,
+			ListedQuest & questId,
+			CRect rect,
+			DWORD color,
+			WndTListBox::DisplayArgs misc
+		);
+	};
+
+	CWndTListBox<ListedQuest, NewQuestDisplayer> m_newQuestListBox;
+	CWndTListBox<ListedQuest, CurrentQuestDisplayer> m_currentQuestListBox;
+
+//	CWndListBox m_WndNewQuestListBox;
+//	CWndListBox m_WndCurrentQuestListBox;
+//	CTexture* m_pNewQuestListIconTexture = nullptr;
+//	CTexture* m_pExpectedQuestListIconTexture = nullptr;
+//	CTexture* m_pCurrentQuestListIconTexture = nullptr;
+//	CTexture* m_pCompleteQuestListIconTexture = nullptr;
 public:
 	 
 	CWndDialog() = default;
@@ -77,9 +120,7 @@ public:
 	void MakeQuestKeyButton( const CString& rstrKeyButton );
 
 private:
-	void RenderNewQuestListIcon( C2DRender* p2DRender );
-	void RenderCurrentQuestListIcon( C2DRender* p2DRender );
-	void AddQuestList( CWndListBox& pWndListBox, int& nQuestListNumber, const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest );
+	std::pair<ListedQuest, bool> MakeListedQuest(const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest);
 
 public:
 

--- a/Source/_Interface/WndDialog.h
+++ b/Source/_Interface/WndDialog.h
@@ -51,8 +51,7 @@ public:
 	CMapStringToString m_mapWordToOriginal;
 
 	struct ListedQuest {
-		CEditString theEditStringClassIsSoBad;
-		CString questName;
+		CEditString displayName;
 		CString strKey;
 		QuestId questId;
 	};

--- a/Source/_Interface/WndDialog.h
+++ b/Source/_Interface/WndDialog.h
@@ -54,7 +54,6 @@ public:
 		CEditString theEditStringClassIsSoBad;
 		CString questName;
 		CString strKey;
-		DWORD dwParam;
 		QuestId questId;
 	};
 
@@ -115,12 +114,11 @@ public:
 	void UpdateButtonEnable();
 	BOOL OnChildNotify(UINT message,UINT nID,LRESULT* pLResult);
 	void RunScript( const char* szKey, DWORD dwParam, DWORD dwQuest );
-	void AddNewQuestList( const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest );
-	void AddCurrentQuestList( const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest );
+	void AddQuestInList(const LPCTSTR lpszWord, const LPCTSTR lpszKey, QuestId dwQuest, bool isNewQuest);
 	void MakeQuestKeyButton( const CString& rstrKeyButton );
 
 private:
-	std::pair<ListedQuest, bool> MakeListedQuest(const LPCTSTR lpszWord, const LPCTSTR lpszKey, const DWORD dwParam, const DWORD dwQuest);
+	std::pair<ListedQuest, bool> MakeListedQuest(const LPCTSTR lpszWord, const LPCTSTR lpszKey, QuestId dwQuest);
 
 public:
 

--- a/Source/_Interface/WndField.h
+++ b/Source/_Interface/WndField.h
@@ -1113,46 +1113,63 @@ public:
 	virtual BOOL OnChildNotify( UINT message, UINT nID, LRESULT* pLResult ); 
 }; 
 
+struct GuildCombatPlayer {
+	CString display;
+	u_long playerId;
+
+	explicit GuildCombatPlayer(u_long playerId);
+
+	void Render(
+		C2DRender * p2DRender, CRect rect,
+		DWORD color, const WndTListBox::DisplayArgs & misc
+	) const;
+
+	struct ById {
+		u_long playerId;
+
+		explicit ById(u_long playerId) : playerId(playerId) {}
+
+		[[nodiscard]] bool operator()(const GuildCombatPlayer & gcp) const {
+			return gcp.playerId == playerId;
+		}
+	};
+};
 
 
-class CWndGuildCombatSelection : public CWndNeuz
-{
-protected:	
-	std::multimap<int, CGuildMember*>	m_mapSelectPlayer;   // 길드리스트...레벨소팅
-
-	std::vector<u_long>					m_vecGuildList   ;   // 길드 리스트
-	std::vector<u_long>					m_vecSelectPlayer;   // 참가자 리스트..
-
-	u_long							m_uidDefender;
-	CTexture						m_TexDefender;
-	int								m_nDefenderIndex;
-	
-	int								nMaxJoinMember;
-	int								nMaxWarMember;
+class CWndGuildCombatSelection : public CWndNeuz {
+private:	
+	u_long   m_uidDefender = -1;
+	int      nMaxJoinMember = 0;
+	int      nMaxWarMember = 0;
+	CTexture m_TexDefender;
 	
 public: 
-	void Reset();
 	CWndGuildCombatSelection();
 	
-	virtual	BOOL	Initialize( CWndBase* pWndParent = NULL, DWORD nType = MB_OK );
-	virtual	BOOL	OnChildNotify( UINT message, UINT nID, LRESULT* pLResult );
-	virtual	void	OnDraw( C2DRender* p2DRender );
-	virtual	void	OnInitialUpdate();
+	BOOL	Initialize( CWndBase* pWndParent = NULL, DWORD nType = MB_OK ) override;
+	BOOL	OnChildNotify( UINT message, UINT nID, LRESULT* pLResult ) override;
+	void	OnDraw( C2DRender* p2DRender ) override;
+	void	OnInitialUpdate() override;
 	void			EnableFinish( BOOL bFlag );		
 
+	void Reset();
 	void			SetDefender( u_long uiPlayer );
 	void			UpDateGuildListBox();
 
-	void			AddCombatPlayer( u_long uiPlayer );
-	void			AddGuildPlayer( u_long uiPlayer );
+	void			SetMemberSize(int nMaxJoin, int nMaxWar);
 
-	void			RemoveCombatPlayer( int nIndex ) ;
-	void			RemoveGuildPlayer( int nIndex ) ;
+	void ReceiveLineup(const std::vector<u_long> & members, u_long defenderId);
 
-	u_long			FindCombatPlayer( u_long uiPlayer );
-	u_long			FindGuildPlayer( u_long uiPlayer );
+private:
+	CWndTListBox<GuildCombatPlayer> & SelectablePlayers();
+	CWndTListBox<GuildCombatPlayer> & CombatPlayers();
 
-	void			SetMemberSize( int nMaxJoin,  int nMaxWar );
+	bool OnConnectedToCombat();
+	bool OnCombatToConnected();
+	bool OnMoveUp();
+	bool OnMoveDown();
+	bool OnFinish();
+	bool OnChooseDefender();
 }; 
 
 class CWndGuildCombatState : public CWndNeuz 

--- a/Source/_Interface/WndNeuz.h
+++ b/Source/_Interface/WndNeuz.h
@@ -90,7 +90,7 @@ public:
 	void SetSizeMax();
 	void SetSizeWnd();
 
-	template<typename T, typename D>
+	template<typename T, typename D = WndTListBox::DefaultDisplayer<typename T>>
 		requires (WndTListBox::DisplayerOf<T, D>)
 	void ReplaceListBox(UINT listboxId);
 };

--- a/Source/_Interface/WndNeuz.h
+++ b/Source/_Interface/WndNeuz.h
@@ -89,25 +89,29 @@ public:
 
 	void SetSizeMax();
 	void SetSizeWnd();
+
+	template<typename T, typename D>
+		requires (WndTListBox::DisplayerOf<T, D>)
+	void ReplaceListBox(UINT listboxId);
 };
 
 template<typename T, typename D>
 	requires (WndTListBox::DisplayerOf<T, D>)
-void CWndTListBox<T, D>::Replace(CWndNeuz & window, UINT listboxId) {
-	const auto itOldComponent = std::ranges::find_if(window.m_wndArrayTemp,
-		[&](const CWndBase * const component) {
-			return component.GetWndId() == listboxId;
+void CWndNeuz::ReplaceListBox(UINT listboxId) {
+	for (int i = 0; i != m_wndArrayTemp.GetSize(); ++i) {
+		CWndBase * oldComponent = (CWndBase *) m_wndArrayTemp.GetAt(i);
+		if (oldComponent->GetWndId() == listboxId) {
+			RemoveWnd(oldComponent);
+			oldComponent->Destroy(true);
+			m_wndArrayTemp.RemoveAt(i);
+			break;
 		}
-	);
-
-	if (itOldComponent != window.m_wndArrayTemp.end()) {
-		itOldComponent->Destroy();
 	}
 
 	CWndTListBox<T, D> * e = new CWndTListBox<T, D>();
 
-	WNDAPPLET * lpWndApplet = m_resMng.GetAt(window.GetWndId());
-	WNDCTRL * pWndCtrl = lpWndApplet->GetAt(listboxId);
+	WNDAPPLET * lpWndApplet = m_resMng.GetAt(GetWndId());
+	WNDCTRL * lpWndCtrl = lpWndApplet->GetAt(listboxId);
 
 	const DWORD dwWndStyle = lpWndCtrl->dwWndStyle;
 	e->Create(dwWndStyle, lpWndCtrl->rect, this, lpWndCtrl->dwWndId);
@@ -115,5 +119,5 @@ void CWndTListBox<T, D>::Replace(CWndNeuz & window, UINT listboxId) {
 		e->m_strTexture = lpWndCtrl->strTexture;
 	e->m_bTile = (lpWndCtrl->bTile != FALSE);
 
-	window.m_wndArrayTemp.Add(e);
+	m_wndArrayTemp.Add(e);
 }

--- a/Source/_Interface/WndNeuz.h
+++ b/Source/_Interface/WndNeuz.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <exception>
+#include <algorithm>
 
 //////////////////////////////////////////////////////////////////////////////////////
 // 윈도의 타이틀 바 
@@ -89,3 +90,29 @@ public:
 	void SetSizeMax();
 	void SetSizeWnd();
 };
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::Replace(CWndNeuz & window, UINT listboxId) {
+	const auto itOldComponent = std::ranges::find_if(window.m_wndArrayTemp,
+		[&](const CWndBase * const component) {
+			return component.GetWndId() == listboxId;
+		}
+	);
+
+	if (itOldComponent != window.m_wndArrayTemp.end()) {
+		itOldComponent->Destroy();
+	}
+
+	CWndTListBox<T, D> * e = new CWndTListBox<T, D>();
+
+	WNDAPPLET * lpWndApplet = m_resMng.GetAt(window.GetWndId());
+	WNDCTRL * pWndCtrl = lpWndApplet->GetAt(listboxId);
+
+	const DWORD dwWndStyle = lpWndCtrl->dwWndStyle;
+	e->Create(dwWndStyle, lpWndCtrl->rect, this, lpWndCtrl->dwWndId);
+	if (lpWndCtrl->strTexture.IsEmpty() == FALSE)
+		e->m_strTexture = lpWndCtrl->strTexture;
+	e->m_bTile = (lpWndCtrl->bTile != FALSE);
+
+	window.m_wndArrayTemp.Add(e);
+}

--- a/Source/_Interface/WndNeuz.h
+++ b/Source/_Interface/WndNeuz.h
@@ -92,6 +92,7 @@ public:
 };
 
 template<typename T, typename D>
+	requires (WndTListBox::DisplayerOf<T, D>)
 void CWndTListBox<T, D>::Replace(CWndNeuz & window, UINT listboxId) {
 	const auto itOldComponent = std::ranges::find_if(window.m_wndArrayTemp,
 		[&](const CWndBase * const component) {

--- a/Source/_Interface/WndTListBox.hpp
+++ b/Source/_Interface/WndTListBox.hpp
@@ -175,7 +175,7 @@ CWndTListBox<T, D>::ViewedItems CWndTListBox<T, D>::UpdateRects() {
 
     m_listed[i].rect = allocatedRect;
 
-    pt.y = allocatedRect.top;
+    pt.y = allocatedRect.bottom;
   }
   const int spanEnd = i;
 

--- a/Source/_Interface/WndTListBox.hpp
+++ b/Source/_Interface/WndTListBox.hpp
@@ -84,8 +84,6 @@ private:
   DWORD m_selectColor = WndTListBox::Color::Select;
 
 public:
-  static void Replace(CWndNeuz & window, UINT listboxId);
-
   CWndTListBox();
 
   void Create(DWORD dwListBoxStyle, RECT & rect, CWndBase * pParentWnd, UINT nID);
@@ -164,8 +162,8 @@ void CWndTListBox<T, D>::OnInitialUpdate() {
   m_wndScrollBar.Create(WBS_DOCKING | WBS_VERT, rect, this, 1000);
   m_wndScrollBar.SetVisible(IsWndStyle(WBS_VSCROLL));
 
-  if (GetFontHeight() == 0) {
-    SetLineHeight(1);
+  if (GetLineHeight() == 0) {
+    SetLineSpace(1);
   }
 }
 

--- a/Source/_Interface/WndTListBox.hpp
+++ b/Source/_Interface/WndTListBox.hpp
@@ -1,0 +1,350 @@
+#pragma once
+
+#include <boost/container/stable_vector.hpp>
+#include <span>
+
+// SquonK, SKHBL
+
+namespace WndTListBox {
+  namespace Color {
+    static constexpr DWORD Font = D3DCOLOR_ARGB(255, 64, 64, 64);
+    static constexpr DWORD Select = D3DCOLOR_ARGB(255, 64, 64, 255);
+    static constexpr DWORD OnMouse = D3DCOLOR_ARGB(255, 255, 128, 0);
+    static constexpr DWORD Invalid = D3DCOLOR_ARGB(255, 170, 170, 170);
+  }
+
+  struct DisplayArgs {
+    bool isSelected;
+    bool isValid;
+    int i;
+  };
+}
+
+class CWndNeuz;
+
+template<typename T, typename Displayer>
+class CWndTListBox : public CWndBase {
+public:
+  static constexpr int VSCROLL_WIDTH = 16;
+  
+  struct Listed {
+    T item;
+    std::optional<CRect> rect = std::nullopt;
+    bool isValid = true;
+  };
+
+  struct ViewedItems {
+    int first;
+    int last;
+  };
+
+  struct UpdateRectsCache {
+    size_t listedSize;
+    int scrollPos;
+    ViewedItems correspondingView;
+  };
+
+  DWORD selectColor = WndTListBox::Color::Select;
+  int lineHeight = 0;
+  Displayer displayer;
+
+private:
+  boost::container::stable_vector<Listed> m_listed;
+  CWndScrollBar m_wndScrollBar;
+
+  int m_nCurSelect = -1;
+  Listed * m_pFocusItem = nullptr;
+  std::optional<UpdateRectsCache> m_updateRectsCache = std::nullopt;
+
+public:
+  static void Replace(CWndNeuz & window, UINT listboxId);
+
+  CWndTListBox();
+
+  void Create(DWORD dwListBoxStyle, RECT & rect, CWndBase * pParentWnd, UINT nID);
+  [[nodiscard]] int GetCurSel() const { return m_nCurSelect; }
+  [[nodiscard]] T * GetCurSelItem() { return m_nCurSelect >= 0 ? &m_listed[m_nCurSelect].item : nullptr; }
+
+  void SetWndRect(CRect rectWnd, BOOL bOnSize = TRUE) override;
+  void OnInitialUpdate() override;
+  void OnDraw(C2DRender * p2DRender) override;
+
+  void OnLButtonUp(UINT nFlags, CPoint point) override;
+  void OnLButtonDown(UINT nFlags, CPoint point) override;
+  void OnRButtonUp(UINT nFlags, CPoint point) override;
+  void OnLButtonDblClk(UINT nFlags, CPoint point) override;
+  void OnSize(UINT nType, int cx, int cy) override;
+  BOOL OnEraseBkgnd(C2DRender * p2DRender) override;
+  void OnSetFocus(CWndBase * pOldWnd) override;
+  BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt) override;
+
+  Listed & Add(T item);
+  void ResetContent();
+  [[nodiscard]] bool IsEmpty() const { return m_listed.empty(); }
+
+private:
+  void PaintListBox(C2DRender * p2DRender);
+  ViewedItems UpdateRects();
+  bool UpdateRectsNeedUpdate();
+
+  [[nodiscard]] int GetLineHeight() const;
+};
+
+template<typename T, typename D>
+CWndTListBox<T, D>::CWndTListBox() {
+  m_byWndType = WTYPE_LISTBOX;
+  m_strTexture = DEF_CTRL_TEXT;
+  m_bTile = TRUE;
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::Create(DWORD dwListBoxStyle, RECT & rect, CWndBase * pParentWnd, UINT nID) {
+  CWndBase::Create(dwListBoxStyle | WBS_CHILD, rect, pParentWnd, nID);
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::SetWndRect(CRect rectWnd, BOOL bOnSize) {
+  m_rectWindow = rectWnd;
+  m_rectClient = m_rectWindow;
+  m_rectClient.DeflateRect(4, 4);
+  if (IsWndStyle(WBS_VSCROLL))
+    m_rectClient.right -= 15;
+  m_wndScrollBar.SetVisible(IsWndStyle(WBS_VSCROLL));
+
+  if (bOnSize) {
+    OnSize(0, m_rectClient.Width(), m_rectClient.Height());
+  }
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnInitialUpdate() {
+  CRect rect = GetWindowRect();
+
+  m_wndScrollBar.Create(WBS_DOCKING | WBS_VERT, rect, this, 1000);
+  m_wndScrollBar.SetVisible(IsWndStyle(WBS_VSCROLL));
+
+  static constexpr int m_nLineSpace = 1;
+  lineHeight = m_pFont->GetMaxHeight() + m_nLineSpace + m_nLineSpace;
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnDraw(C2DRender * p2DRender) {
+  PaintListBox(p2DRender);
+
+  if (IsWndStyle(WBS_VSCROLL)) {
+    const int nPage = GetClientRect().Height() / GetLineHeight();
+    const int nRange = static_cast<int>(m_listed.size());
+
+    m_wndScrollBar.SetVisible(TRUE);
+    m_wndScrollBar.SetScrollRange(0, nRange);
+    m_wndScrollBar.SetScrollPage(nPage);
+  } else {
+    m_wndScrollBar.SetVisible(FALSE);
+  }
+}
+
+template<typename T, typename D>
+CWndTListBox<T, D>::ViewedItems CWndTListBox<T, D>::UpdateRects() {
+  if (!UpdateRectsNeedUpdate()) {
+    return m_updateRectsCache->correspondingView;
+  }
+  
+  int i;
+
+  // Above window
+  for (i = 0; i < m_wndScrollBar.GetScrollPos(); ++i) {
+    if (std::cmp_greater_equal(i, m_listed.size())) break;
+    m_listed[i].rect = std::nullopt;
+  }
+
+  // On window
+  CPoint pt(3, 3);
+
+  const int nScrollBarWidth = IsWndStyle(WBS_VSCROLL) ? m_wndScrollBar.GetClientRect().Width() : 0;
+
+  const int spanBegin = i;
+  for (i = m_wndScrollBar.GetScrollPos(); std::cmp_less(i, m_listed.size()); ++i) {
+    const CRect allocatedRect(
+      pt.x,
+      pt.y,
+      pt.x + m_rectWindow.Width() - nScrollBarWidth,
+      pt.y + GetLineHeight()
+    );
+
+    if (allocatedRect.top > m_rectWindow.bottom) break;
+
+    m_listed[i].rect = allocatedRect;
+
+    pt.y = allocatedRect.top;
+  }
+  const int spanEnd = i;
+
+  // Under window
+  while (std::cmp_less(i, m_listed.size())) {
+    m_listed[i].rect = std::nullopt;
+    ++i;
+  }
+
+  m_updateRectsCache = UpdateRectsCache{
+    .listedSize = m_listed.size(),
+    .scrollPos = m_wndScrollBar.GetScrollPos(),
+    .correspondingView = ViewedItems{ spanBegin, spanEnd }
+  };
+
+  return m_updateRectsCache->correspondingView;
+}
+
+template<typename T, typename D>
+bool CWndTListBox<T, D>::UpdateRectsNeedUpdate() {
+  // TODO: check m_updateRectsCache
+  return true;
+}
+
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::PaintListBox(C2DRender * p2DRender) {
+  const CPoint mousePoint = GetMousePoint();
+
+  const auto displayed = UpdateRects();
+
+  for (int i = displayed.first; i != displayed.last; ++i) {
+    DWORD textColor;
+    if (!m_listed[i].isValid) {
+      textColor = WndTListBox::Color::Invalid;
+    } else if (i == m_nCurSelect) {
+      textColor = selectColor;
+    } else if (m_listed[i].rect->PtInRect(mousePoint)) {
+      textColor = WndTListBox::Color::OnMouse;
+    } else {
+      textColor = WndTListBox::Color::Font;
+    }
+
+    WndTListBox::DisplayArgs args = {
+      .isSelected = i == m_nCurSelect,
+      .isValid = m_listed[i].isValid,
+      .i = i
+    };
+
+    displayer.Render(p2DRender, m_listed[i].item, m_listed[i].rect.value(), textColor, args);
+  }
+}
+
+template<typename T, typename D>
+int CWndTListBox<T, D>::GetLineHeight() const {
+  return lineHeight;
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnLButtonUp(UINT nFlags, CPoint point) {
+  const auto displayed = UpdateRects();
+
+  for (int i = displayed.first; i != displayed.last; ++i) {
+    Listed & listed = m_listed[i];
+
+    if (!listed.isValid) continue;
+
+    if (listed.rect->PtInRect(point)) {
+      if (m_pFocusItem == &listed) {
+        CWndBase * pWnd = m_pParentWnd;
+        pWnd->OnChildNotify(WNM_SELCHANGE, m_nIdWnd, (LRESULT *)&listed);
+        return;
+      }
+    }
+  }
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnLButtonDown(UINT nFlags, CPoint point) {
+  const auto displayed = UpdateRects();
+
+  for (int i = displayed.first; i != displayed.last; ++i) {
+    Listed & listed = m_listed[i];
+
+    if (!listed.isValid) continue;
+
+    if (listed.rect->PtInRect(point)) {
+      m_nCurSelect = i;
+      m_pFocusItem = &listed;
+    }
+  }
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnRButtonUp(UINT nFlags, CPoint point) {
+  const auto displayed = UpdateRects();
+
+  for (int i = displayed.first; i != displayed.last; ++i) {
+    Listed & listed = m_listed[i];
+
+    if (!listed.isValid) continue;
+
+    if (listed.rect->PtInRect(point)) {
+      if (m_pFocusItem == &listed) {
+        CWndBase * pWnd = m_pParentWnd;
+        pWnd->OnChildNotify(WNM_SELCANCEL, m_nIdWnd, (LRESULT *)&listed);
+        return;
+      }
+    }
+  }
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnLButtonDblClk(UINT nFlags, CPoint point) {
+  const auto displayed = UpdateRects();
+
+  for (int i = displayed.first; i != displayed.last; ++i) {
+    Listed & listed = m_listed[i];
+
+    if (!listed.isValid) continue;
+
+    if (listed.rect->PtInRect(point)) {
+      if (m_pFocusItem == &listed) {
+        CWndBase * pWnd = m_pParentWnd;
+        while (pWnd->GetStyle() & WBS_CHILD)
+          pWnd = pWnd->GetParentWnd();
+        pWnd->OnChildNotify(WNM_DBLCLK, m_nIdWnd, (LRESULT *)m_pFocusItem);
+        return;
+      }
+    }
+  }
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnSize(UINT nType, int cx, int cy) {
+  CRect rect = GetWindowRect();
+  if (IsWndStyle(WBS_VSCROLL))
+    rect.left = rect.right - VSCROLL_WIDTH;
+  m_wndScrollBar.SetVisible(IsWndStyle(WBS_VSCROLL));
+  m_wndScrollBar.SetWndRect(rect);
+  CWndBase::OnSize(nType, cx, cy);
+}
+
+template<typename T, typename D>
+BOOL CWndTListBox<T, D>::OnEraseBkgnd(C2DRender * p2DRender) {
+  return TRUE;
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::OnSetFocus(CWndBase * pOldWnd) {
+}
+
+template<typename T, typename D>
+BOOL CWndTListBox<T, D>::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt) {
+  m_wndScrollBar.MouseWheel(zDelta);
+  return TRUE;
+}
+
+template<typename T, typename D>
+CWndTListBox<T, D>::Listed & CWndTListBox<T, D>::Add(T item) {
+  m_updateRectsCache = std::nullopt;
+  return m_listed.emplace_back(Listed{ .item = item });
+}
+
+template<typename T, typename D>
+void CWndTListBox<T, D>::ResetContent() {
+  m_nCurSelect = -1;
+  m_pFocusItem = NULL;
+  m_listed.clear();
+  m_wndScrollBar.SetScrollPos(0, FALSE);
+  m_updateRectsCache = std::nullopt;
+}


### PR DESCRIPTION
- Define a `Render()` method to explain how to render your list box elements
- You can put in your list box the elements you want. Yay no more weird cast!
- `CWndNeuz` knows how to replace its vanilla listboxes with `TListBoxes`
- TListBox have been implemented for `/createitem`, npc dialogs and guild combat selection.
- And you do not even need to pay ten thousands of french francs to use this
  -  Especially as this currency was great replaced by euros